### PR TITLE
Fix typo in klipper setup guide

### DIFF
--- a/Klipper/README.md
+++ b/Klipper/README.md
@@ -38,7 +38,7 @@
       <img src=Images/klipper_menuconfig.png width="800" /><br/>
    3. Once the configuration is selected, press `q` to exit,  and "Yes" when  asked to save the configuration.
    4. Run the command `make`
-   5. The `klipper.uf2` file will be generated in the folder `home/pi/kliiper/out` when the `make` command completed. And you can use the windows computer under the same LAN as raspberry pi to copy `klipper.uf2` from raspberry pi to the computer with `pscp` command in the CMD terminal. such as `pscp -C pi@192.168.0.101:/home/pi/klipper/out/klipper.uf2 c:\klipper.uf2`(The terminal may prompt that `The server's host key is not cached` and ask `Store key in cache?((y/n)`, Please type `y` to store. And then it will ask for a password, please type the default password `raspberry` for raspberry pi)
+   5. The `klipper.uf2` file will be generated in the folder `home/pi/klipper/out` when the `make` command completed. And you can use the windows computer under the same LAN as raspberry pi to copy `klipper.uf2` from raspberry pi to the computer with `pscp` command in the CMD terminal. such as `pscp -C pi@192.168.0.101:/home/pi/klipper/out/klipper.uf2 c:\klipper.uf2`(The terminal may prompt that `The server's host key is not cached` and ask `Store key in cache?((y/n)`, Please type `y` to store. And then it will ask for a password, please type the default password `raspberry` for raspberry pi)
 
 ## Firmware Installation
 


### PR DESCRIPTION
This fixes the typo of `kliiper`, changing it to `klipper` in the output path after running `make`.